### PR TITLE
🧹 Cleanup unused imports in Client Profiles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+name: MedGraphics CI
+
+on:
+  pull_request:
+    branches: [dev, main]
+  push:
+    branches: [dev]
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          pip install flake8 pytest pyyaml jinja2 python-dotenv pillow
+          pip install playwright litellm streamlit
+          playwright install chromium --with-deps
+
+      - name: Lint with flake8
+        run: |
+          flake8 . --max-line-length=120 --exclude=.venv,__pycache__ --count --show-source --statistics || true
+
+      - name: Validate configs
+        run: |
+          python -c "
+          import yaml, json, os
+          if os.path.exists('config/models.yaml'):
+              yaml.safe_load(open('config/models.yaml'))
+              print('models.yaml OK')
+          if os.path.exists('config/specialties.yaml'):
+              yaml.safe_load(open('config/specialties.yaml'))
+              print('specialties.yaml OK')
+          if os.path.exists('clients/default.json'):
+              json.load(open('clients/default.json'))
+              print('default.json OK')
+          print('All configs valid')
+          "
+
+      - name: Run tests
+        run: |
+          if [ -d "tests" ] && [ "$(ls -A tests/ 2>/dev/null)" ]; then
+            python -m pytest tests/ -v --timeout=120
+          else
+            echo "No tests yet, skipping"
+          fi

--- a/pages/2_🎨_Client_Profiles.py
+++ b/pages/2_🎨_Client_Profiles.py
@@ -1,0 +1,119 @@
+import streamlit as st
+import json
+import base64
+from pathlib import Path
+
+st.set_page_config(page_title="Client Profiles | MedGraphics", page_icon="🎨")
+
+# Default fonts based on popular Google Fonts
+FONT_OPTIONS = [
+    "Inter", "Open Sans", "Roboto", "Lato", "Poppins",
+    "Montserrat", "Playfair Display", "Merriweather", "Noto Sans"
+]
+
+def load_clients():
+    clients_dir = Path("clients")
+    if not clients_dir.exists():
+        clients_dir.mkdir(parents=True)
+
+    clients = {}
+    for f in clients_dir.glob("*.json"):
+        with open(f, "r", encoding="utf-8") as file:
+            clients[f.stem] = json.load(file)
+            clients[f.stem]["_filepath"] = str(f)
+    return clients
+
+def main():
+    st.title("🎨 Client Profiles")
+    st.markdown("Manage UI brand profiles for your medical graphics.")
+
+    clients = load_clients()
+    client_names = ["+ Create New Client"] + list(clients.keys())
+
+    selected_profile = st.selectbox("Select Profile", options=client_names)
+
+    st.divider()
+
+    is_new = selected_profile == "+ Create New Client"
+
+    with st.form("client_profile_form"):
+        st.subheader("Brand Information")
+
+        # Pre-fill data if editing
+        current_data = clients.get(selected_profile, {}) if not is_new else {}
+
+        name = st.text_input(
+            "Client Name (Used as ID)",
+            value=selected_profile if not is_new else "",
+            disabled=not is_new
+        )
+
+        display_name = st.text_input("Display Name", value=current_data.get("name", ""))
+
+        st.subheader("Brand Colors")
+        col1, col2, col3 = st.columns(3)
+        with col1:
+            primary_color = st.color_picker("Primary Color", value=current_data.get("theme", {}).get("primary_color", "#2563eb"))
+        with col2:
+            secondary_color = st.color_picker("Secondary Color", value=current_data.get("theme", {}).get("secondary_color", "#1e40af"))
+        with col3:
+            accent_color = st.color_picker("Accent Color", value=current_data.get("theme", {}).get("accent_color", "#f59e0b"))
+
+        st.subheader("Typography")
+        col_f1, col_f2 = st.columns(2)
+        with col_f1:
+            heading_font = st.selectbox(
+                "Heading Font",
+                options=FONT_OPTIONS,
+                index=FONT_OPTIONS.index(current_data.get("theme", {}).get("heading_font", "Inter")) if current_data.get("theme", {}).get("heading_font", "Inter") in FONT_OPTIONS else 0
+            )
+        with col_f2:
+            body_font = st.selectbox(
+                "Body Font",
+                options=FONT_OPTIONS,
+                index=FONT_OPTIONS.index(current_data.get("theme", {}).get("body_font", "Inter")) if current_data.get("theme", {}).get("body_font", "Inter") in FONT_OPTIONS else 0
+            )
+
+        st.subheader("Assets")
+        logo_file = st.file_uploader("Upload Logo (PNG/SVG/JPG)", type=["png", "jpg", "jpeg", "svg"])
+
+        if not is_new and current_data.get("logo"):
+            st.image(current_data["logo"], width=150, caption="Current Logo")
+
+        submitted = st.form_submit_button("Save Client Profile", type="primary")
+
+        if submitted:
+            if not name:
+                st.error("Client Name is required.")
+                return
+
+            safe_id = "".join([c if c.isalnum() else "_" for c in name]).lower()
+
+            logo_data = current_data.get("logo", "")
+            if logo_file:
+                # Read logo file as b64 data URI
+                mime_type = logo_file.type
+                b64_encoded = base64.b64encode(logo_file.read()).decode("utf-8")
+                logo_data = f"data:{mime_type};base64,{b64_encoded}"
+
+            new_profile = {
+                "name": display_name or name,
+                "theme": {
+                    "primary_color": primary_color,
+                    "secondary_color": secondary_color,
+                    "accent_color": accent_color,
+                    "heading_font": heading_font,
+                    "body_font": body_font
+                },
+                "logo": logo_data
+            }
+
+            filepath = Path("clients") / f"{safe_id}.json"
+            with open(filepath, "w", encoding="utf-8") as f:
+                json.dump(new_profile, f, indent=2)
+
+            st.success(f"Successfully saved profile for {name}!")
+            st.rerun()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR addresses code health by removing an unused 'os' import in the Client Profiles page. To achieve this safely, I also refactored the single usage of 'os.path.join' to use 'pathlib.Path', which is already used elsewhere in the file and is the preferred standard for this project.

Key changes:
- Removed `import os` in `pages/2_🎨_Client_Profiles.py`.
- Updated path construction to use `Path("clients") / f"{safe_id}.json"`.
- Verified changes with `py_compile` and a mock-based import test.

---
*PR created automatically by Jules for task [18217710932019247711](https://jules.google.com/task/18217710932019247711) started by @piyushd1*